### PR TITLE
Fix mobile menu toggle

### DIFF
--- a/datos.html
+++ b/datos.html
@@ -495,12 +495,13 @@
             });
             
             // Inicializar el menú móvil
-            const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+            const mobileMenuBtn = document.getElementById('mobile-menu-button');
             const mobileMenu = document.getElementById('mobile-menu');
-            
+
             if (mobileMenuBtn && mobileMenu) {
                 mobileMenuBtn.addEventListener('click', function() {
                     mobileMenu.classList.toggle('hidden');
+                    mobileMenu.classList.toggle('block');
                 });
             }
         });

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -51,14 +51,15 @@ const setupScrollSpy = () => {
 };
 
 const setupMobileMenu = () => {
-  const mobileMenuBtn = document.querySelector('.mobile-menu-btn');
-  const navLinks = document.getElementById('nav-links');
-  
+  // Adaptar a la estructura de la plantilla actual
+  const mobileMenuBtn = document.getElementById('mobile-menu-button');
+  const navLinks = document.getElementById('mobile-menu');
+
   if (!mobileMenuBtn || !navLinks) return;
-  
+
   mobileMenuBtn.addEventListener('click', () => {
     navLinks.classList.toggle('hidden');
-    navLinks.classList.toggle('flex');
+    navLinks.classList.toggle('block');
   });
 };
 

--- a/utils/navigation.js
+++ b/utils/navigation.js
@@ -50,7 +50,7 @@ export function setupScrollSpy(navSelector = '#navbar', linkSelector = '.nav-lin
  * @param {string} navbarSelector - Selector para el elemento de navegación
  * @param {string} expandedClass - Clase CSS para marcar el menú expandido
  */
-export function setupMobileMenu(buttonSelector = '.mobile-menu-btn', navbarSelector = '#navbar', expandedClass = 'expanded') {
+export function setupMobileMenu(buttonSelector = '#mobile-menu-button', navbarSelector = '#navbar', expandedClass = 'expanded') {
     const mobileMenuBtn = document.querySelector(buttonSelector);
     const navbar = document.querySelector(navbarSelector);
     


### PR DESCRIPTION
## Summary
- ensure mobile menu script matches current markup
- wire up mobile menu handler correctly on Datos page
- update mobile menu utils to default to new selector

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_683fc025144083258d870e5390d1d623