### PR TITLE
Fix mobile menu behavior on small screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -230,7 +230,6 @@ a.btn:hover, a.btn:focus {
     }
     
     #mobile-menu {
-        display: block;
         padding: 0.5rem 0;
     }
 }


### PR DESCRIPTION
## Summary
- stop forcing mobile menu to display with CSS so JS can hide it

## Testing
- `npm run lint` *(fails: A config object is using the `env` key)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684229704f908325b4156a796358f413